### PR TITLE
fix required PyTorch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ url={https://openreview.net/forum?id=rkgOLb-0W},
 ```
 
 ## Software Requirements
-Python 2.7, NLTK and PyTorch 0.2 are required for the current codebase.
+Python 2.7, NLTK and PyTorch 0.3 are required for the current codebase.
 
 ## Steps
 
-1. Install PyTorch 0.2 and NLTK
+1. Install PyTorch 0.3 and NLTK
 
 2. Download PTB data. Note that the two tasks, i.e., language modeling and unsupervised parsing share the same model strucutre but require different formats of the PTB data. For language modeling we need the standard 10,000 word [Penn Treebank corpus](https://github.com/pytorch/examples/tree/75e435f98ab7aaa7f82632d4e633e8e03070e8ac/word_language_model/data/penn) data, and for parsing we need [Penn Treebank Parsed](https://catalog.ldc.upenn.edu/ldc99t42) data.
 


### PR DESCRIPTION
Hi Yikang,

Thanks for have the nice code released. 

I was just running the code with Python2.7 and current PyTorch 0.2 under a typical Anaconda environment, but got an error on log_softmax, which is addressed by [this issue](https://github.com/pytorch/pytorch/issues/3235). Fortunately, the code works well with PyTorch 0.3, hence I suggest to update PyTorch 0.2 to PyTorch 0.3 in README.md for the convenience of future researchers. 

Best,
Freda